### PR TITLE
Add dashboard "button" to update number of controllers

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -23,6 +23,8 @@
 #include <RobotXmlParser.h>
 #include <mechanisms/StateMgrHelper.h>
 
+#include <frc/shuffleboard/Shuffleboard.h>
+
 using namespace std;
 
 void Robot::RobotInit() 
@@ -64,6 +66,17 @@ void Robot::RobotInit()
  */
 void Robot::RobotPeriodic() 
 {
+    //check if driver wants to re-initialize TeleopControl
+    if(frc::SmartDashboard::GetBoolean("Reset TeleopControl?", false) == true)
+    {
+        //If num of controllers = 0, re construct controllers
+        m_controller = TeleopControl::GetInstance();
+        // frc::SmartDashboard::PutBoolean("Reset TeleopControl?", false);
+
+        //Add indicator that button was successfully pressed
+        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("RobotPeriodic"), string("ControllerCheck"),string("Re-initialized TeleopControl for added controllers"));
+    }
+
     if (m_chassis != nullptr)
     {
         m_chassis->UpdateOdometry();

--- a/src/main/cpp/TeleopControl.cpp
+++ b/src/main/cpp/TeleopControl.cpp
@@ -31,6 +31,8 @@
 #include <frc/DriverStation.h>
 #include <utils/Logger.h>
 
+#include <frc/smartdashboard/SmartDashboard.h>
+
 using namespace frc;
 using namespace std;
 
@@ -90,6 +92,9 @@ void TeleopControl::Initialize()
 			m_numControllers++;
 		}
 	}
+
+	//add "button" so that number of TeleopControl can be re-initialized if a new controller is add
+	frc::SmartDashboard::PutBoolean("Reset TeleopControl?", false);
 
 
     // Initialize the items to not defined


### PR DESCRIPTION
Only works when the code thinks there are no controllers plugged in, like after powering on robot.
Used to re-init TeleopControl after power on so we don't need to restart robot code to add controllers.